### PR TITLE
feat(oke): add support for configuring oke

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Repository | Referenced Tags/Branches
 [Governance](https://github.com/oci-landing-zones/terraform-oci-modules-governance) | [v0.1.5 tag](https://github.com/oci-landing-zones/terraform-oci-modules-governance/releases/tag/v0.1.5)
 [Security](https://github.com/oci-landing-zones/terraform-oci-modules-security) | [v0.2.0 tag](https://github.com/oci-landing-zones/terraform-oci-modules-security/releases/tag/v0.2.0)
 [Observability & Monitoring](https://github.com/oci-landing-zones/terraform-oci-modules-observability) | [v0.2.3 tag](https://github.com/oci-landing-zones/terraform-oci-modules-observability/releases/tag/v0.2.3)
-[Secure Workloads](https://github.com/oci-landing-zones/terraform-oci-modules-workloads) | [v0.2.0 tag](https://github.com/oci-landing-zones/terraform-oci-modules-workloads/releases/tag/v0.2.0)
+[Workloads](https://github.com/oci-landing-zones/terraform-oci-modules-workloads) | [v0.2.0 tag](https://github.com/oci-landing-zones/terraform-oci-modules-workloads/releases/tag/v0.2.0)
 
 Such approach allows for the build out of custom Landing Zones in a declarative fashion, without any Terraform coding knowledge.
 
@@ -56,6 +56,7 @@ logging_configuration | service_logs_output.json and custom_logs_output.json
 vaults_configuration | vaults_output.json and keys_output.json
 tags_configuration | tags_output.json
 instances_configuration | instances_output.json
+oke_clusters_configuration | oke_clusters_output.json
 
 ## How to Invoke the Orchestrator
 
@@ -131,11 +132,11 @@ When you select *github* as Configuration Source for Input Files, you'll see a f
 
 * **GitHub Token**: You can use GitHub's Personal Access Token (classic) or Fine-grained personal access tokens (see this [reference](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/)). While both are valid, we recommend the use of Fine-grained personal access tokens as, beside giving you the option to fine-tune the operation access to your repo, you can select the repos you want to give access to.
   
-* **GitHub Repository**: This is the name of your GitHub repository unique in your userorganization. E.g.: *test-orch* (without the .git).
+* **GitHub Repository**: This is the name of your GitHub repository including your Github organization. E.g.: *org/repo-name* (without the .git).
   
 * **GitHub Branch**: This is your desired branch where/to get/put the input/output information. E.g.: *main*.
   
-* **Configuration Files**: The configuration files are given as relative reference to the file in your repository. E.g.: *iam/identity.json* (for a file in test-orch.git/iam/identity.json).
+* **Configuration Files**: The configuration files are given as relative reference to the file in your repository. E.g.: *iam/identity.json* (for a file in test-org.git/iam/identity.json).
   
 * **Dependency Files**: The relative reference to where the dependency files (created in a previous operation) are stored in your repository. E.g.: *output/compartments_output.json* and *output/network_output.json*.
   
@@ -211,7 +212,7 @@ Please consult the [security guide](./SECURITY.md) for our responsible security 
 
 ## License
 
-Copyright (c) 2023,2024 Oracle and/or its affiliates.
+Copyright (c) 2025 Oracle and/or its affiliates.
 
 Released under the Universal Permissive License v1.0 as shown at
 <https://oss.oracle.com/licenses/upl/>.

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,33 +8,35 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
-| <a name="provider_oci"></a> [oci](#provider\_oci) | 6.15.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.3 |
+| <a name="provider_oci"></a> [oci](#provider\_oci) | 7.8.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_oci_lz_alarms"></a> [oci\_lz\_alarms](#module\_oci\_lz\_alarms) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//alarms | v0.2.1 |
-| <a name="module_oci_lz_budgets"></a> [oci\_lz\_budgets](#module\_oci\_lz\_budgets) | git::https://github.com/oci-landing-zones/terraform-oci-modules-governance.git//budgets | release-0.1.4 |
+| <a name="module_oci_lz_alarms"></a> [oci\_lz\_alarms](#module\_oci\_lz\_alarms) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//alarms | v0.2.3 |
+| <a name="module_oci_lz_bastions"></a> [oci\_lz\_bastions](#module\_oci\_lz\_bastions) | git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//bastion | v0.2.0 |
+| <a name="module_oci_lz_budgets"></a> [oci\_lz\_budgets](#module\_oci\_lz\_budgets) | git::https://github.com/oci-landing-zones/terraform-oci-modules-governance.git//budgets | v0.1.5 |
 | <a name="module_oci_lz_cloud_guard"></a> [oci\_lz\_cloud\_guard](#module\_oci\_lz\_cloud\_guard) | git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//cloud-guard | v0.2.0 |
-| <a name="module_oci_lz_compartments"></a> [oci\_lz\_compartments](#module\_oci\_lz\_compartments) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//compartments | v0.2.7 |
-| <a name="module_oci_lz_compute"></a> [oci\_lz\_compute](#module\_oci\_lz\_compute) | git::https://github.com/oci-landing-zones/terraform-oci-modules-workloads.git//cis-compute-storage | v0.1.9 |
-| <a name="module_oci_lz_dynamic_groups"></a> [oci\_lz\_dynamic\_groups](#module\_oci\_lz\_dynamic\_groups) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//dynamic-groups | v0.2.7 |
-| <a name="module_oci_lz_events"></a> [oci\_lz\_events](#module\_oci\_lz\_events) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//events | v0.2.1 |
-| <a name="module_oci_lz_groups"></a> [oci\_lz\_groups](#module\_oci\_lz\_groups) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//groups | v0.2.7 |
-| <a name="module_oci_lz_home_region_events"></a> [oci\_lz\_home\_region\_events](#module\_oci\_lz\_home\_region\_events) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//events | v0.2.1 |
-| <a name="module_oci_lz_identity_domains"></a> [oci\_lz\_identity\_domains](#module\_oci\_lz\_identity\_domains) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//identity-domains | v0.2.7 |
-| <a name="module_oci_lz_logging"></a> [oci\_lz\_logging](#module\_oci\_lz\_logging) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//logging | v0.2.1 |
-| <a name="module_oci_lz_network"></a> [oci\_lz\_network](#module\_oci\_lz\_network) | git::https://github.com/oci-landing-zones/terraform-oci-modules-networking.git | v0.7.2 |
-| <a name="module_oci_lz_nlb"></a> [oci\_lz\_nlb](#module\_oci\_lz\_nlb) | git::https://github.com/oci-landing-zones/terraform-oci-modules-networking.git//modules/nlb | v0.7.2 |
-| <a name="module_oci_lz_notifications"></a> [oci\_lz\_notifications](#module\_oci\_lz\_notifications) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//notifications | v0.2.1 |
-| <a name="module_oci_lz_policies"></a> [oci\_lz\_policies](#module\_oci\_lz\_policies) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//policies | v0.2.7 |
+| <a name="module_oci_lz_compartments"></a> [oci\_lz\_compartments](#module\_oci\_lz\_compartments) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//compartments | v0.2.9 |
+| <a name="module_oci_lz_compute"></a> [oci\_lz\_compute](#module\_oci\_lz\_compute) | git::https://github.com/oci-landing-zones/terraform-oci-modules-workloads.git//cis-compute-storage | v0.2.0 |
+| <a name="module_oci_lz_dynamic_groups"></a> [oci\_lz\_dynamic\_groups](#module\_oci\_lz\_dynamic\_groups) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//dynamic-groups | v0.2.9 |
+| <a name="module_oci_lz_events"></a> [oci\_lz\_events](#module\_oci\_lz\_events) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//events | v0.2.3 |
+| <a name="module_oci_lz_groups"></a> [oci\_lz\_groups](#module\_oci\_lz\_groups) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//groups | v0.2.9 |
+| <a name="module_oci_lz_home_region_events"></a> [oci\_lz\_home\_region\_events](#module\_oci\_lz\_home\_region\_events) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//events | v0.2.3 |
+| <a name="module_oci_lz_identity_domains"></a> [oci\_lz\_identity\_domains](#module\_oci\_lz\_identity\_domains) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//identity-domains | v0.2.9 |
+| <a name="module_oci_lz_logging"></a> [oci\_lz\_logging](#module\_oci\_lz\_logging) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//logging | v0.2.3 |
+| <a name="module_oci_lz_network"></a> [oci\_lz\_network](#module\_oci\_lz\_network) | git::https://github.com/oci-landing-zones/terraform-oci-modules-networking.git | v0.7.5 |
+| <a name="module_oci_lz_nlb"></a> [oci\_lz\_nlb](#module\_oci\_lz\_nlb) | git::https://github.com/oci-landing-zones/terraform-oci-modules-networking.git//modules/nlb | v0.7.5 |
+| <a name="module_oci_lz_notifications"></a> [oci\_lz\_notifications](#module\_oci\_lz\_notifications) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//notifications | v0.2.3 |
+| <a name="module_oci_lz_oke"></a> [oci\_lz\_oke](#module\_oci\_lz\_oke) | git::https://github.com/oci-landing-zones/terraform-oci-modules-workloads.git//cis-oke | v0.2.0 |
+| <a name="module_oci_lz_policies"></a> [oci\_lz\_policies](#module\_oci\_lz\_policies) | git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam.git//policies | v0.2.9 |
 | <a name="module_oci_lz_scanning"></a> [oci\_lz\_scanning](#module\_oci\_lz\_scanning) | git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//vss | v0.2.0 |
 | <a name="module_oci_lz_security_zones"></a> [oci\_lz\_security\_zones](#module\_oci\_lz\_security\_zones) | git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//security-zones | v0.2.0 |
-| <a name="module_oci_lz_service_connectors"></a> [oci\_lz\_service\_connectors](#module\_oci\_lz\_service\_connectors) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//service-connectors | v0.2.1 |
-| <a name="module_oci_lz_streams"></a> [oci\_lz\_streams](#module\_oci\_lz\_streams) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//streams | v0.2.1 |
-| <a name="module_oci_lz_tags"></a> [oci\_lz\_tags](#module\_oci\_lz\_tags) | git::https://github.com/oci-landing-zones/terraform-oci-modules-governance.git//tags | release-0.1.4 |
+| <a name="module_oci_lz_service_connectors"></a> [oci\_lz\_service\_connectors](#module\_oci\_lz\_service\_connectors) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//service-connectors | v0.2.3 |
+| <a name="module_oci_lz_streams"></a> [oci\_lz\_streams](#module\_oci\_lz\_streams) | git::https://github.com/oci-landing-zones/terraform-oci-modules-observability.git//streams | v0.2.3 |
+| <a name="module_oci_lz_tags"></a> [oci\_lz\_tags](#module\_oci\_lz\_tags) | git::https://github.com/oci-landing-zones/terraform-oci-modules-governance.git//tags | v0.1.5 |
 | <a name="module_oci_lz_vaults"></a> [oci\_lz\_vaults](#module\_oci\_lz\_vaults) | git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//vaults | v0.2.0 |
 | <a name="module_oci_lz_zpr"></a> [oci\_lz\_zpr](#module\_oci\_lz\_zpr) | git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//zpr | v0.2.0 |
 
@@ -42,6 +44,7 @@
 
 | Name | Type |
 |------|------|
+| [local_file.bastions_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.compartments_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.custom_logs_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.identity_domains_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
@@ -49,6 +52,7 @@
 | [local_file.keys_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.network_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.nlbs_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.oke_clusters_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.service_logs_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.streams_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.tags_output](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
@@ -64,6 +68,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarms_configuration"></a> [alarms\_configuration](#input\_alarms\_configuration) | n/a | `any` | `null` | no |
+| <a name="input_bastions_configuration"></a> [bastions\_configuration](#input\_bastions\_configuration) | n/a | `any` | `null` | no |
 | <a name="input_budgets_configuration"></a> [budgets\_configuration](#input\_budgets\_configuration) | n/a | `any` | `null` | no |
 | <a name="input_cloud_guard_configuration"></a> [cloud\_guard\_configuration](#input\_cloud\_guard\_configuration) | n/a | `any` | `null` | no |
 | <a name="input_compartments_configuration"></a> [compartments\_configuration](#input\_compartments\_configuration) | n/a | `any` | `null` | no |
@@ -90,6 +95,9 @@
 | <a name="input_nlbs_dependency"></a> [nlbs\_dependency](#input\_nlbs\_dependency) | n/a | `any` | `null` | no |
 | <a name="input_notifications_configuration"></a> [notifications\_configuration](#input\_notifications\_configuration) | n/a | `any` | `null` | no |
 | <a name="input_object_storage_configuration"></a> [object\_storage\_configuration](#input\_object\_storage\_configuration) | n/a | `any` | `null` | no |
+| <a name="input_oke_clusters_configuration"></a> [oke\_clusters\_configuration](#input\_oke\_clusters\_configuration) | n/a | `any` | `null` | no |
+| <a name="input_oke_clusters_dependency"></a> [oke\_clusters\_dependency](#input\_oke\_clusters\_dependency) | n/a | `any` | `null` | no |
+| <a name="input_oke_workers_configuration"></a> [oke\_workers\_configuration](#input\_oke\_workers\_configuration) | n/a | `any` | `null` | no |
 | <a name="input_output_path"></a> [output\_path](#input\_output\_path) | n/a | `string` | `null` | no |
 | <a name="input_policies_configuration"></a> [policies\_configuration](#input\_policies\_configuration) | n/a | `any` | `null` | no |
 | <a name="input_private_key_password"></a> [private\_key\_password](#input\_private\_key\_password) | n/a | `string` | `null` | no |
@@ -119,4 +127,5 @@
 | <a name="output_network_resources"></a> [network\_resources](#output\_network\_resources) | Provisioned networking resources |
 | <a name="output_nlb_resources"></a> [nlb\_resources](#output\_nlb\_resources) | Provisioned NLB resources |
 | <a name="output_observability_resources"></a> [observability\_resources](#output\_observability\_resources) | Provisioned streaming resources |
+| <a name="output_oke_cluster_resources"></a> [oke\_cluster\_resources](#output\_oke\_cluster\_resources) | Provisioned OKE Cluster resources |
 | <a name="output_security_resources"></a> [security\_resources](#output\_security\_resources) | Provisioned security resources |

--- a/locals.tf
+++ b/locals.tf
@@ -48,7 +48,13 @@ locals {
   ext_dep_instances_map = var.instances_dependency != null ? try(var.instances_dependency.instances, jsondecode(file(var.instances_dependency)).instances, null) : null
   instances_dependency  = merge({ for k, v in coalesce(local.ext_dep_instances_map, {}) : k => { "id" : v.id, "private_ip" : v.private_ip } }, { for k, v in(length(module.oci_lz_compute) > 0 ? module.oci_lz_compute[0].instances : {}) : k => { "id" : v.id, "private_ip" : v.create_vnic_details[0].private_ip } }, { for k, v in(length(module.oci_lz_compute) > 0 ? module.oci_lz_compute[0].secondary_vnics : {}) : k => { "id" : v.id, "private_ip" : v.private_ip_address } })
 
+  # var.oke_clusters_dependency
+  ext_dep_oke_clusters_map = var.oke_clusters_dependency != null ? try(var.oke_clusters_dependency.clusters, jsondecode(file(var.oke_clusters_dependency)).oke_clusters, null) : null
+  oke_clusters_dependency  = merge({ for k, v in coalesce(local.ext_dep_oke_clusters_map, {}) : k => { "id" : v.id } }, { for k, v in(length(module.oci_lz_oke) > 0 ? module.oci_lz_oke[0].clusters : {}) : k => { "id" : v.id } }, { for k, v in(length(module.oci_lz_oke) > 0 ? module.oci_lz_oke[0].node_pools : {}) : k => { "id" : v.id } })
+
+
   # var.nlbs_dependency
   ext_dep_nlbs_map = var.nlbs_dependency != null ? try(var.nlbs_dependency.nlbs_private_ips, jsondecode(file(var.nlbs_dependency)).nlbs_private_ips, null) : null
   nlbs_dependency  = { for k, v in coalesce(local.ext_dep_nlbs_map, {}) : k => { "id" : v.id } }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -77,6 +77,14 @@ output "compute_resources" {
   }
 }
 
+output "oke_cluster_resources" {
+  description = "Provisioned OKE Cluster resources"
+  value = {
+    oke_clusters = length(module.oci_lz_oke) > 0 ? module.oci_lz_oke[0].clusters : {}
+    oke_workers  = length(module.oci_lz_oke) > 0 ? module.oci_lz_oke[0].node_pools : {}
+  }
+}
+
 output "nlb_resources" {
   description = "Provisioned NLB resources"
   value = {
@@ -168,6 +176,13 @@ resource "local_file" "instances_output" {
   content = jsonencode({ "instances" : { for k, v in module.oci_lz_compute[0].instances : k => { "id" : v.id, "private_ip" : v.create_vnic_details[0].private_ip } },
   "secondary_vnics" : { for k, v in module.oci_lz_compute[0].secondary_vnics : k => { "id" : v.id, "private_ip" : v.private_ip_address } } })
   filename = "${var.output_path}/instances_output.json"
+}
+
+resource "local_file" "oke_clusters_output" {
+  count = var.output_path != null && length(module.oci_lz_oke) > 0 ? 1 : 0
+  content = jsonencode({ "oke_clusters" : { for k, v in module.oci_lz_oke[0].clusters : k => { "id" : v.id } },
+  "oke_workers" : { for k, v in module.oci_lz_oke[0].node_pools : k => { "id" : v.id } } })
+  filename = "${var.output_path}/oke_clusters_output.json"
 }
 
 resource "local_file" "nlbs_output" {

--- a/rms-facade/SPEC.md
+++ b/rms-facade/SPEC.md
@@ -9,9 +9,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 5.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | n/a |
-| <a name="provider_oci"></a> [oci](#provider\_oci) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | 5.45.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.5.0 |
+| <a name="provider_oci"></a> [oci](#provider\_oci) | 7.12.0 |
 
 ## Modules
 
@@ -23,6 +23,7 @@
 
 | Name | Type |
 |------|------|
+| [github_repository_file.bastions](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.compartments](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.custom_logs](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.identity_domains](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
@@ -30,11 +31,13 @@
 | [github_repository_file.keys](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.networking](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.nlbs](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.oke_clusters](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.service_logs](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.streams](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.tags](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.topics](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.vaults](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [oci_objectstorage_object.bastions](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.compartments](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.custom_logs](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.identity_domains](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
@@ -42,6 +45,7 @@
 | [oci_objectstorage_object.keys](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.networking](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.nlbs](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
+| [oci_objectstorage_object.oke_clusters](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.service_logs](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.streams](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
 | [oci_objectstorage_object.tags](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/objectstorage_object) | resource |
@@ -63,6 +67,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_configuration_source"></a> [configuration\_source](#input\_configuration\_source) | The source where configuration files are pulled from. | `string` | `"url"` | no |
 | <a name="input_fingerprint"></a> [fingerprint](#input\_fingerprint) | n/a | `string` | `null` | no |
+| <a name="input_github_base_url"></a> [github\_base\_url](#input\_github\_base\_url) | GitHub base API endpoint. Required when working with GitHub Enterprise. The value must end with a slash. E.g. https://example.com/ | `string` | `null` | no |
 | <a name="input_github_configuration_branch"></a> [github\_configuration\_branch](#input\_github\_configuration\_branch) | n/a | `string` | `null` | no |
 | <a name="input_github_configuration_files"></a> [github\_configuration\_files](#input\_github\_configuration\_files) | n/a | `list(string)` | `null` | no |
 | <a name="input_github_configuration_repo"></a> [github\_configuration\_repo](#input\_github\_configuration\_repo) | n/a | `string` | `null` | no |

--- a/rms-facade/get_configurations.tf
+++ b/rms-facade/get_configurations.tf
@@ -96,6 +96,10 @@ locals {
   # Object Storage
   object_storage_configuration = local.merged_input_configs != null ? contains(keys(local.merged_input_configs), "object_storage_configuration") ? local.merged_input_configs.object_storage_configuration : null : null
 
-  # Compute
-  instances_configuration = local.merged_input_configs != null ? contains(keys(local.merged_input_configs), "instances_configuration") ? local.merged_input_configs.instances_configuration : null : null
+  # Workloads 
+  instances_configuration    = local.merged_input_configs != null ? contains(keys(local.merged_input_configs), "instances_configuration") ? local.merged_input_configs.instances_configuration : null : null
+  oke_clusters_configuration = local.merged_input_configs != null ? contains(keys(local.merged_input_configs), "oke_clusters_configuration") ? local.merged_input_configs.oke_clusters_configuration : null : null
+  oke_workers_configuration  = local.merged_input_configs != null ? contains(keys(local.merged_input_configs), "oke_workers_configuration") ? local.merged_input_configs.oke_workers_configuration : null : null
+
 }
+

--- a/rms-facade/get_dependencies.tf
+++ b/rms-facade/get_dependencies.tf
@@ -62,5 +62,7 @@ locals {
   functions_dependency    = local.all_json_dependencies_map != null ? contains(keys(local.all_json_dependencies_map), "functions") ? { "functions" : local.all_json_dependencies_map.functions } : null : null
   vaults_dependency       = local.all_json_dependencies_map != null ? contains(keys(local.all_json_dependencies_map), "vaults") ? { "vaults" : local.all_json_dependencies_map.vaults } : null : null
   instances_dependency    = local.all_json_dependencies_map != null ? merge(contains(keys(local.all_json_dependencies_map), "instances") ? { "instances" : local.all_json_dependencies_map.instances } : {}, contains(keys(local.all_json_dependencies_map), "private_ips") ? { "private_ips" : local.all_json_dependencies_map.private_ips } : {}) : null
+  oke_clusters_dependency = local.all_json_dependencies_map != null ? merge(contains(keys(local.all_json_dependencies_map), "oke_clusters") ? { "oke_clusters" : local.all_json_dependencies_map.oke_clusters } : {}, contains(keys(local.all_json_dependencies_map), "oke_workers") ? { "oke_workers" : local.all_json_dependencies_map.oke_workers } : {}) : null
   nlbs_dependency         = local.all_json_dependencies_map != null ? contains(keys(local.all_json_dependencies_map), "nlbs_private_ips") ? { "nlbs_private_ips" : local.all_json_dependencies_map.nlbs_private_ips } : null : null
 }
+

--- a/rms-facade/main.tf
+++ b/rms-facade/main.tf
@@ -46,8 +46,10 @@ module "oci_lz_orchestrator" {
   tags_configuration    = local.tags_configuration
   # Object Storage
   object_storage_configuration = local.object_storage_configuration
-  # Compute
-  instances_configuration = local.instances_configuration
+  # Workloads 
+  instances_configuration    = local.instances_configuration
+  oke_clusters_configuration = local.oke_clusters_configuration
+  oke_workers_configuration  = local.oke_workers_configuration
 
   # Dependencies
   compartments_dependency = local.compartments_dependency
@@ -60,5 +62,7 @@ module "oci_lz_orchestrator" {
   functions_dependency    = local.functions_dependency
   vaults_dependency       = local.vaults_dependency
   instances_dependency    = local.instances_dependency
+  oke_clusters_dependency = local.oke_clusters_dependency
   nlbs_dependency         = local.nlbs_dependency
 }
+

--- a/rms-facade/outputs.tf
+++ b/rms-facade/outputs.tf
@@ -2,75 +2,80 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 locals {
-    compartments_output = length(module.oci_lz_orchestrator.iam_resources.compartments) > 0 ? {
-        "compartments" : {for k, v in module.oci_lz_orchestrator.iam_resources.compartments : k => {"id" : v.id}}
-    } : null
-    identity_domains_output = length(module.oci_lz_orchestrator.iam_resources.identity_domains) > 0 ? {
-        "identity_domains" : {for k, v in module.oci_lz_orchestrator.iam_resources.identity_domains : k => {"id" : v.id}}
-    } : null
-    network_output = module.oci_lz_orchestrator.network_resources != null ? {
-        "network_resources" : {
-            "vcns" : {for k, v in module.oci_lz_orchestrator.network_resources.vcns : k => {"id" : v.id}},
-            "subnets" : {for k, v in module.oci_lz_orchestrator.network_resources.subnets : k => {"id" : v.id}},
-            "network_security_groups" : {for k, v in module.oci_lz_orchestrator.network_resources.network_security_groups : k => {"id" : v.id}}
-            "dynamic_routing_gateways" : {for k, v in module.oci_lz_orchestrator.network_resources.dynamic_routing_gateways : k => {"id" : v.id}}
-            "drg_attachments" : {for k, v in module.oci_lz_orchestrator.network_resources.drg_attachments : k => {"id" : v.id}}
-            "remote_peering_connections" : {for k, v in module.oci_lz_orchestrator.network_resources.remote_peering_connections : k => {"id" : v.id}}
-            "local_peering_gateways" : {for k, v in module.oci_lz_orchestrator.network_resources.local_peering_gateways : k => {"id" : v.id}}
-            "drg_route_tables" : {for k, v in module.oci_lz_orchestrator.network_resources.drg_route_tables : k => {"id" : v.id}}
-            "dns_resolver" : {for k, v in module.oci_lz_orchestrator.network_resources.dns_resolver : k => {"id" : v.id}}
-            "dns_zones" : {for k, v in module.oci_lz_orchestrator.network_resources.dns_zones : k => {"id" : v.id}}
-            "dns_views" : {for k, v in module.oci_lz_orchestrator.network_resources.dns_views : k => {"id" : v.id}}
-        }    
-    } : null
-    topics_output = length(module.oci_lz_orchestrator.observability_resources.notifications_topics) > 0 ? {
-        "topics" : {for k, v in module.oci_lz_orchestrator.observability_resources.notifications_topics : k => {"id" : v.id}}
-    } : null
-    streams_output = length(module.oci_lz_orchestrator.observability_resources.streams) > 0 ? {
-        "streams" : {for k, v in module.oci_lz_orchestrator.observability_resources.streams : k => {"id" : v.id}}
-    } : null
-    custom_logs_output = length(module.oci_lz_orchestrator.observability_resources.custom_logs) > 0 ? {
-        "custom_logs" : {for k, v in module.oci_lz_orchestrator.observability_resources.custom_logs : k => {"id" : v.id, "compartment_id" : v.compartment_id}}
-    } : null
-    service_logs_output = length(module.oci_lz_orchestrator.observability_resources.service_logs) > 0 ? {
-        "service_logs" : {for k, v in module.oci_lz_orchestrator.observability_resources.service_logs : k => {"id" : v.id, "compartment_id" : v.compartment_id}}
-    } : null
-    vaults_output = length(module.oci_lz_orchestrator.security_resources.vaults) > 0 ? {
-        "vaults" : {for k, v in module.oci_lz_orchestrator.security_resources.vaults : k => {"management_endpoint" : v.management_endpoint}}
-    } : null
-    keys_output = length(module.oci_lz_orchestrator.security_resources.keys) > 0 ? {
-        "keys" : {for k, v in module.oci_lz_orchestrator.security_resources.keys : k => {"id" : v.id}}
-    } : null
-    bastions_output = length(module.oci_lz_orchestrator.security_resources.bastions) > 0 ? {
-        "bastions" : {for k, v in module.oci_lz_orchestrator.security_resources.bastions : k => {"id" : v.id}}
-    } : null
-    tags_output = length(module.oci_lz_orchestrator.governance_resources.tags) > 0 ? {
-        "tags" : {for k, v in module.oci_lz_orchestrator.governance_resources.tags : k => {"id" : v.id}}
-    } : null
-    instances_output = length(module.oci_lz_orchestrator.compute_resources.instances) > 0 ? {
-        "instances" : {for k, v in module.oci_lz_orchestrator.compute_resources.instances : k => {"id" : v.id, "private_ip" : v.create_vnic_details[0].private_ip}},
-        "secondary_vnics" : {for k, v in module.oci_lz_orchestrator.compute_resources.secondary_vnics : k => {"id" : v.id, "private_ip" : v.private_ip_address}}
-    } : null
-    nlbs_output = length(module.oci_lz_orchestrator.nlb_resources.nlbs_private_ips) > 0 ? {
-        "nlbs_private_ips" : {for k, v in module.oci_lz_orchestrator.nlb_resources.nlbs_private_ips : k => {"id" : v.private_ips[0].id}},
-        "nlbs_public_ips" : {for k, v in module.oci_lz_orchestrator.nlb_resources.nlbs_public_ips : k => {"private_ip_id" : v.private_ip_id, "id" : v.id}}
-    } : null
+  compartments_output = length(module.oci_lz_orchestrator.iam_resources.compartments) > 0 ? {
+    "compartments" : { for k, v in module.oci_lz_orchestrator.iam_resources.compartments : k => { "id" : v.id } }
+  } : null
+  identity_domains_output = length(module.oci_lz_orchestrator.iam_resources.identity_domains) > 0 ? {
+    "identity_domains" : { for k, v in module.oci_lz_orchestrator.iam_resources.identity_domains : k => { "id" : v.id } }
+  } : null
+  network_output = module.oci_lz_orchestrator.network_resources != null ? {
+    "network_resources" : {
+      "vcns" : { for k, v in module.oci_lz_orchestrator.network_resources.vcns : k => { "id" : v.id } },
+      "subnets" : { for k, v in module.oci_lz_orchestrator.network_resources.subnets : k => { "id" : v.id } },
+      "network_security_groups" : { for k, v in module.oci_lz_orchestrator.network_resources.network_security_groups : k => { "id" : v.id } }
+      "dynamic_routing_gateways" : { for k, v in module.oci_lz_orchestrator.network_resources.dynamic_routing_gateways : k => { "id" : v.id } }
+      "drg_attachments" : { for k, v in module.oci_lz_orchestrator.network_resources.drg_attachments : k => { "id" : v.id } }
+      "remote_peering_connections" : { for k, v in module.oci_lz_orchestrator.network_resources.remote_peering_connections : k => { "id" : v.id } }
+      "local_peering_gateways" : { for k, v in module.oci_lz_orchestrator.network_resources.local_peering_gateways : k => { "id" : v.id } }
+      "drg_route_tables" : { for k, v in module.oci_lz_orchestrator.network_resources.drg_route_tables : k => { "id" : v.id } }
+      "dns_resolver" : { for k, v in module.oci_lz_orchestrator.network_resources.dns_resolver : k => { "id" : v.id } }
+      "dns_zones" : { for k, v in module.oci_lz_orchestrator.network_resources.dns_zones : k => { "id" : v.id } }
+      "dns_views" : { for k, v in module.oci_lz_orchestrator.network_resources.dns_views : k => { "id" : v.id } }
+    }
+  } : null
+  topics_output = length(module.oci_lz_orchestrator.observability_resources.notifications_topics) > 0 ? {
+    "topics" : { for k, v in module.oci_lz_orchestrator.observability_resources.notifications_topics : k => { "id" : v.id } }
+  } : null
+  streams_output = length(module.oci_lz_orchestrator.observability_resources.streams) > 0 ? {
+    "streams" : { for k, v in module.oci_lz_orchestrator.observability_resources.streams : k => { "id" : v.id } }
+  } : null
+  custom_logs_output = length(module.oci_lz_orchestrator.observability_resources.custom_logs) > 0 ? {
+    "custom_logs" : { for k, v in module.oci_lz_orchestrator.observability_resources.custom_logs : k => { "id" : v.id, "compartment_id" : v.compartment_id } }
+  } : null
+  service_logs_output = length(module.oci_lz_orchestrator.observability_resources.service_logs) > 0 ? {
+    "service_logs" : { for k, v in module.oci_lz_orchestrator.observability_resources.service_logs : k => { "id" : v.id, "compartment_id" : v.compartment_id } }
+  } : null
+  vaults_output = length(module.oci_lz_orchestrator.security_resources.vaults) > 0 ? {
+    "vaults" : { for k, v in module.oci_lz_orchestrator.security_resources.vaults : k => { "management_endpoint" : v.management_endpoint } }
+  } : null
+  keys_output = length(module.oci_lz_orchestrator.security_resources.keys) > 0 ? {
+    "keys" : { for k, v in module.oci_lz_orchestrator.security_resources.keys : k => { "id" : v.id } }
+  } : null
+  bastions_output = length(module.oci_lz_orchestrator.security_resources.bastions) > 0 ? {
+    "bastions" : { for k, v in module.oci_lz_orchestrator.security_resources.bastions : k => { "id" : v.id } }
+  } : null
+  tags_output = length(module.oci_lz_orchestrator.governance_resources.tags) > 0 ? {
+    "tags" : { for k, v in module.oci_lz_orchestrator.governance_resources.tags : k => { "id" : v.id } }
+  } : null
+  instances_output = length(module.oci_lz_orchestrator.compute_resources.instances) > 0 ? {
+    "instances" : { for k, v in module.oci_lz_orchestrator.compute_resources.instances : k => { "id" : v.id, "private_ip" : v.create_vnic_details[0].private_ip } },
+    "secondary_vnics" : { for k, v in module.oci_lz_orchestrator.compute_resources.secondary_vnics : k => { "id" : v.id, "private_ip" : v.private_ip_address } }
+  } : null
+  oke_clusters_output = length(module.oci_lz_orchestrator.oke_cluster_resources.oke_clusters) > 0 ? {
+    "oke_clusters" : { for k, v in module.oci_lz_orchestrator.oke_cluster_resources.oke_clusters : k => { "id" : v.id } },
+    "oke_workers" : { for k, v in module.oci_lz_orchestrator.oke_cluster_resources.oke_node_pools : k => { "id" : v.id } }
+  } : null
+  nlbs_output = length(module.oci_lz_orchestrator.nlb_resources.nlbs_private_ips) > 0 ? {
+    "nlbs_private_ips" : { for k, v in module.oci_lz_orchestrator.nlb_resources.nlbs_private_ips : k => { "id" : v.private_ips[0].id } },
+    "nlbs_public_ips" : { for k, v in module.oci_lz_orchestrator.nlb_resources.nlbs_public_ips : k => { "private_ip_id" : v.private_ip_id, "id" : v.id } }
+  } : null
 
-    compartments_output_file_name     = "compartments_output.json"
-    identity_domains_output_file_name = "identity_domains_output.json"
-    networking_output_file_name       = "network_output.json"
-    topics_output_file_name           = "topics_output.json"
-    streams_output_file_name          = "streams_output.json"
-    service_logs_output_file_name     = "service_logs_output.json"
-    custom_logs_output_file_name      = "custom_logs_output.json"
-    vaults_output_file_name           = "vaults_output.json"
-    keys_output_file_name             = "keys_output.json"
-    bastions_output_file_name         = "bastions_output.json"
-    tags_output_file_name             = "tags_output.json"
-    instances_output_file_name        = "instances_output.json"
-    nlbs_output_file_name             = "nlbs_output.json"
+  compartments_output_file_name     = "compartments_output.json"
+  identity_domains_output_file_name = "identity_domains_output.json"
+  networking_output_file_name       = "network_output.json"
+  topics_output_file_name           = "topics_output.json"
+  streams_output_file_name          = "streams_output.json"
+  service_logs_output_file_name     = "service_logs_output.json"
+  custom_logs_output_file_name      = "custom_logs_output.json"
+  vaults_output_file_name           = "vaults_output.json"
+  keys_output_file_name             = "keys_output.json"
+  bastions_output_file_name         = "bastions_output.json"
+  tags_output_file_name             = "tags_output.json"
+  instances_output_file_name        = "instances_output.json"
+  oke_clusters_output_file_name     = "oke_clusters_output.json"
+  nlbs_output_file_name             = "nlbs_output.json"
 
-    github_repository_name = var.github_configuration_repo != null ? split("/", var.github_configuration_repo)[1] : null # Use only repository name
+  github_repository_name = var.github_configuration_repo != null ? split("/", var.github_configuration_repo)[1] : null # Use only repository name
 }
 
 ### Writing compartments output to bucket
@@ -181,6 +186,14 @@ resource "oci_objectstorage_object" "instances" {
   object    = var.oci_object_prefix != null ? "${var.oci_object_prefix}/${local.instances_output_file_name}" : local.instances_output_file_name
 }
 
+resource "oci_objectstorage_object" "oke_clusters" {
+  count     = var.save_output && (lower(var.configuration_source) == "ocibucket" || lower(var.url_dependency_source) == "ocibucket") && local.oke_clusters_output != null ? 1 : 0
+  bucket    = coalesce(var.oci_configuration_bucket, var.url_dependency_source_oci_bucket, "__void__")
+  content   = jsonencode(local.oke_clusters_output)
+  namespace = data.oci_objectstorage_namespace.this[0].namespace
+  object    = var.oci_object_prefix != null ? "${var.oci_object_prefix}/${local.oke_clusters_output_file_name}" : local.oke_clusters_output_file_name
+}
+
 ### Writing NLBs output to OCI bucket
 resource "oci_objectstorage_object" "nlbs" {
   count     = var.save_output && (lower(var.configuration_source) == "ocibucket" || lower(var.url_dependency_source) == "ocibucket") && local.nlbs_output != null ? 1 : 0
@@ -201,7 +214,7 @@ resource "oci_objectstorage_object" "nlbs" {
 
 ### Writing compartments output to GitHub repository
 resource "github_repository_file" "compartments" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.compartments_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.compartments_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.compartments_output_file_name}" : local.compartments_output_file_name
@@ -214,7 +227,7 @@ resource "github_repository_file" "compartments" {
 
 ### Writing identity_domains output to GitHub repository
 resource "github_repository_file" "identity_domains" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.identity_domains_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.identity_domains_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.identity_domains_output_file_name}" : local.identity_domains_output_file_name
@@ -227,7 +240,7 @@ resource "github_repository_file" "identity_domains" {
 
 ### Writing networking output to GitHub repository
 resource "github_repository_file" "networking" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.network_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.network_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.networking_output_file_name}" : local.networking_output_file_name
@@ -240,7 +253,7 @@ resource "github_repository_file" "networking" {
 
 ### Writing notification topics output to GitHub repository
 resource "github_repository_file" "topics" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.topics_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.topics_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.topics_output_file_name}" : local.topics_output_file_name
@@ -253,7 +266,7 @@ resource "github_repository_file" "topics" {
 
 ### Writing streams output to GitHub repository
 resource "github_repository_file" "streams" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.streams_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.streams_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.streams_output_file_name}" : local.streams_output_file_name
@@ -266,7 +279,7 @@ resource "github_repository_file" "streams" {
 
 ### Writing service logs output to GitHub repository
 resource "github_repository_file" "service_logs" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.service_logs_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.service_logs_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.service_logs_output_file_name}" : local.service_logs_output_file_name
@@ -279,7 +292,7 @@ resource "github_repository_file" "service_logs" {
 
 ### Writing custom logs output to GitHub repository
 resource "github_repository_file" "custom_logs" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.custom_logs_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.custom_logs_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.custom_logs_output_file_name}" : local.custom_logs_output_file_name
@@ -292,7 +305,7 @@ resource "github_repository_file" "custom_logs" {
 
 ### Writing vaults output to GitHub repository
 resource "github_repository_file" "vaults" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.vaults_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.vaults_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.vaults_output_file_name}" : local.vaults_output_file_name
@@ -305,7 +318,7 @@ resource "github_repository_file" "vaults" {
 
 ### Writing keys output to GitHub repository
 resource "github_repository_file" "keys" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.keys_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.keys_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.keys_output_file_name}" : local.keys_output_file_name
@@ -318,7 +331,7 @@ resource "github_repository_file" "keys" {
 
 ### Writing bastions output to GitHub repository
 resource "github_repository_file" "bastions" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.bastions_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.bastions_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.bastions_output_file_name}" : local.bastions_output_file_name
@@ -331,7 +344,7 @@ resource "github_repository_file" "bastions" {
 
 ### Writing tags output to GitHub repository
 resource "github_repository_file" "tags" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.tags_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.tags_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.tags_output_file_name}" : local.tags_output_file_name
@@ -344,7 +357,7 @@ resource "github_repository_file" "tags" {
 
 ### Writing instances output to GitHub repository
 resource "github_repository_file" "instances" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.instances_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.instances_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.instances_output_file_name}" : local.instances_output_file_name
@@ -355,9 +368,21 @@ resource "github_repository_file" "instances" {
   overwrite_on_create = true
 }
 
+resource "github_repository_file" "oke_clusters" {
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.oke_clusters_output != null ? 1 : 0
+  repository          = local.github_repository_name
+  branch              = var.github_configuration_branch
+  file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.oke_clusters_output_file_name}" : local.oke_clusters_output_file_name
+  content             = jsonencode(local.oke_clusters_output)
+  commit_message      = "Managed by OCI Landing Zones Orchestrator."
+  commit_author       = "Terraform User"
+  commit_email        = "terraform@example.com"
+  overwrite_on_create = true
+}
+
 ### Writing NLBs output to GitHub repository
 resource "github_repository_file" "nlbs" {
-  count = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.nlbs_output != null ? 1 : 0
+  count               = var.save_output && (lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github") && local.nlbs_output != null ? 1 : 0
   repository          = local.github_repository_name
   branch              = var.github_configuration_branch
   file                = var.github_file_prefix != null ? "${var.github_file_prefix}/${local.nlbs_output_file_name}" : local.nlbs_output_file_name
@@ -375,8 +400,8 @@ data "github_repository" "this" {
 }
 
 locals {
-  object_storage_output_string = "Files saved to OCI bucket ${coalesce(var.oci_configuration_bucket, var.url_dependency_source_oci_bucket, "__void__")}: ${join(",", compact([try(oci_objectstorage_object.compartments[0].object, ""), try(oci_objectstorage_object.identity_domains[0].object, ""), try(oci_objectstorage_object.networking[0].object, ""), try(oci_objectstorage_object.topics[0].object, ""), try(oci_objectstorage_object.streams[0].object, ""), try(oci_objectstorage_object.service_logs[0].object, ""), try(oci_objectstorage_object.custom_logs[0].object, ""), try(oci_objectstorage_object.vaults[0].object, ""), try(oci_objectstorage_object.keys[0].object, ""), try(oci_objectstorage_object.bastions[0].object, ""), try(oci_objectstorage_object.tags[0].object, ""), try(oci_objectstorage_object.instances[0].object, ""), try(oci_objectstorage_object.nlbs[0].object, "")]))}"
-  github_output_string         = "Files saved to GitHub repository ${coalesce(var.github_configuration_repo, "__void__")}, branch ${coalesce(var.github_configuration_branch, "__void__")}: ${join(",", compact([try(github_repository_file.compartments[0].file, ""), try(github_repository_file.identity_domains[0].file, ""), try(github_repository_file.networking[0].file, ""), try(github_repository_file.topics[0].file, ""), try(github_repository_file.streams[0].file, ""), try(github_repository_file.service_logs[0].file, ""), try(github_repository_file.custom_logs[0].file, ""), try(github_repository_file.vaults[0].file, ""), try(github_repository_file.keys[0].file, ""), try(github_repository_file.bastions[0].file, ""), try(github_repository_file.tags[0].file, ""), try(github_repository_file.instances[0].file, ""), try(github_repository_file.nlbs[0].file, "")]))}"
+  object_storage_output_string = "Files saved to OCI bucket ${coalesce(var.oci_configuration_bucket, var.url_dependency_source_oci_bucket, "__void__")}: ${join(",", compact([try(oci_objectstorage_object.compartments[0].object, ""), try(oci_objectstorage_object.identity_domains[0].object, ""), try(oci_objectstorage_object.networking[0].object, ""), try(oci_objectstorage_object.topics[0].object, ""), try(oci_objectstorage_object.streams[0].object, ""), try(oci_objectstorage_object.service_logs[0].object, ""), try(oci_objectstorage_object.custom_logs[0].object, ""), try(oci_objectstorage_object.vaults[0].object, ""), try(oci_objectstorage_object.keys[0].object, ""), try(oci_objectstorage_object.bastions[0].object, ""), try(oci_objectstorage_object.tags[0].object, ""), try(oci_objectstorage_object.oke_clusters[0].object, ""), try(oci_objectstorage_object.instances[0].object, ""), try(oci_objectstorage_object.nlbs[0].object, "")]))}"
+  github_output_string         = "Files saved to GitHub repository ${coalesce(var.github_configuration_repo, "__void__")}, branch ${coalesce(var.github_configuration_branch, "__void__")}: ${join(",", compact([try(github_repository_file.compartments[0].file, ""), try(github_repository_file.identity_domains[0].file, ""), try(github_repository_file.networking[0].file, ""), try(github_repository_file.topics[0].file, ""), try(github_repository_file.streams[0].file, ""), try(github_repository_file.service_logs[0].file, ""), try(github_repository_file.custom_logs[0].file, ""), try(github_repository_file.vaults[0].file, ""), try(github_repository_file.keys[0].file, ""), try(github_repository_file.bastions[0].file, ""), try(github_repository_file.tags[0].file, ""), try(github_repository_file.oke_clusters[0].file, ""), try(github_repository_file.instances[0].file, ""), try(github_repository_file.nlbs[0].file, "")]))}"
   output_string                = var.save_output ? (lower(var.configuration_source) == "ocibucket" || lower(var.url_dependency_source) == "ocibucket" ? local.object_storage_output_string : lower(var.configuration_source) == "github" || lower(var.url_dependency_source) == "github" ? local.github_output_string : "") : null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,16 @@ variable "instances_configuration" {
   default = null
 }
 
+variable "oke_clusters_configuration" {
+  type    = any
+  default = null
+}
+
+variable "oke_workers_configuration" {
+  type    = any
+  default = null
+}
+
 variable "object_storage_configuration" {
   type    = any
   default = null
@@ -216,6 +226,11 @@ variable "instances_dependency" {
   default = null
 }
 
+variable "oke_clusters_dependency" {
+  type    = any
+  default = null
+}
+
 variable "nlbs_dependency" {
   type    = any
   default = null
@@ -225,3 +240,4 @@ variable "output_path" {
   type    = string
   default = null
 }
+

--- a/workloads.tf
+++ b/workloads.tf
@@ -18,3 +18,12 @@ module "oci_lz_compute" {
   #  file_system_dependency  = TBD
 }
 
+module "oci_lz_oke" {
+  count                   = var.oke_clusters_configuration != null || var.oke_workers_configuration != null ? 1 : 0
+  source                  = "git::https://github.com/oci-landing-zones/terraform-oci-modules-workloads.git//cis-oke?ref=v0.2.0"
+  clusters_configuration  = var.oke_clusters_configuration
+  workers_configuration   = var.oke_workers_configuration
+  compartments_dependency = local.compartments_dependency
+  network_dependency      = local.network_dependency
+  kms_dependency          = local.kms_dependency
+}


### PR DESCRIPTION
- rename compute file to follow repository naming based on where module is imported from

Tested:
- deployed directly through local TF and ORM using RMS-facade
- save output verified (only local TF)